### PR TITLE
fix(livery-bridge): fix version check only accepting identical versions

### DIFF
--- a/src/util/semver.ts
+++ b/src/util/semver.ts
@@ -6,7 +6,7 @@ export function semver(version: string) {
   if (!matches) {
     throw new Error(`Invalid semantic version: ${version}`);
   }
-  const [major, minor, patch, prerelease, buildmetadata] = matches;
+  const [, major, minor, patch, prerelease, buildmetadata] = matches;
   return { major, minor, patch, prerelease, buildmetadata };
 }
 


### PR DESCRIPTION
fix(livery-bridge): fix version check only accepting identical versions

fix the the bridge sending a reject message when versions aren't identical

LLS-2936